### PR TITLE
Rename `destructure-case` to `slime-dcase`.

### DIFF
--- a/slime-js.el
+++ b/slime-js.el
@@ -94,7 +94,7 @@ If you want swank-js to run on a differnet port, add it as the third element to 
 
 (defun slime-js-event-hook-function (event)
   (when (equal "JS" (slime-lisp-implementation-type))
-    (destructure-case event
+    (slime-dcase event
       ((:new-package package prompt)
        (let ((buffer (slime-connection-output-buffer)))
          (setf (slime-lisp-package) package)


### PR DESCRIPTION
The `destructure-case` macro defined in `swank.lisp` was renamed to `slime-dcase` back in 2014. This fix just changes this name in `slime-js.el` so that `swank-js` will work with recent SLIME versions.
